### PR TITLE
Chore/set project encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
   </description>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
 
     <!-- These properties are used in both the BOM as well as operaton-parent and subprojects -->
@@ -634,5 +635,20 @@
     <system>GitHub</system>
     <url>https://github.com/operaton/operaton/issues/</url>
   </issueManagement>
-
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.9</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>dependency-convergence</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>


### PR DESCRIPTION
I had problems on my local machine because there are cyrillic characters in the source code as well as in generated code, which caused maven to constantly fail. Setting the encoding fixed it.